### PR TITLE
fix: block unsupported chains to prevent locked funds

### DIFF
--- a/coinfello/SKILL.md
+++ b/coinfello/SKILL.md
@@ -233,6 +233,7 @@ These are approximate ranges under normal network conditions. L2s like Base are 
 - **No smart account**: Run `create_account` before `send_prompt`. The CLI checks for a saved private key and address in config.
 - **Not signed in**: Run `sign_in` before `send_prompt` if the server requires authentication.
 - **Invalid chain name**: The CLI throws an error listing valid viem chain names.
+- **Unsupported chain**: The CLI rejects chains where CoinFello infrastructure and MetaMask delegation contracts aren't available. Supported chains: Ethereum, OP Mainnet, BNB Smart Chain, Polygon, Base, Arbitrum One, Linea, Sepolia, Base Sepolia. **Funding a smart account on any other chain will result in permanently locked funds.**
 - **Read-only response**: If the server returns a text response with no transaction, the CLI prints it and exits without creating a delegation.
 
 ## Bug Reports & Support

--- a/coinfello/references/REFERENCE.md
+++ b/coinfello/references/REFERENCE.md
@@ -183,20 +183,21 @@ Each subdelegation is created with a unique random salt to ensure delegation uni
 
 ## Supported Chains
 
-Any chain exported by `viem/chains` is supported. Chains with a QuickNode slug configured get routed through the paid QuickNode RPC when `RPC_BASE_URL` and `RPC_API_KEY` are set; all others fall back to the chain's default public RPC.
+> **⚠️ Only the chains listed below are supported. Sending funds to your smart account on any other chain will result in permanently locked funds.** The MetaMask delegation framework contracts must be deployed on a chain AND CoinFello infrastructure must be configured for it. The CLI enforces this restriction and will reject transactions on unsupported chains.
 
-| Chain Name    | Chain ID | Network                  | QuickNode Support |
-| ------------- | -------- | ------------------------ | ----------------- |
-| `mainnet`     | 1        | Ethereum mainnet         | Yes               |
-| `sepolia`     | 11155111 | Ethereum Sepolia testnet | Yes               |
-| `polygon`     | 137      | Polygon PoS              | Yes               |
-| `arbitrum`    | 42161    | Arbitrum One             | Yes               |
-| `optimism`    | 10       | OP Mainnet               | Yes               |
-| `base`        | 8453     | Base                     | Yes               |
-| `baseSepolia` | 84532    | Base Sepolia testnet     | Yes               |
-| `linea`       | 59144    | Linea mainnet            | Yes               |
-| `bsc`         | 56       | BNB Smart Chain          | Yes               |
-| `avalanche`   | 43114    | Avalanche C-Chain        | No (public RPC)   |
+| Chain Name    | Chain ID | Network                  |
+| ------------- | -------- | ------------------------ |
+| `mainnet`     | 1        | Ethereum mainnet         |
+| `optimism`    | 10       | OP Mainnet               |
+| `bsc`         | 56       | BNB Smart Chain          |
+| `polygon`     | 137      | Polygon PoS              |
+| `base`        | 8453     | Base                     |
+| `arbitrum`    | 42161    | Arbitrum One             |
+| `linea`       | 59144    | Linea mainnet            |
+| `sepolia`     | 11155111 | Ethereum Sepolia testnet |
+| `baseSepolia` | 84532    | Base Sepolia testnet     |
+
+When `RPC_BASE_URL` and `RPC_API_KEY` are set, RPC requests for these chains are routed through QuickNode. Otherwise, the chain's default public RPC is used.
 
 ## API Endpoints
 
@@ -335,3 +336,4 @@ All `amount` fields are in the token's smallest unit (e.g. `5000000` for 5 USDC 
 | `No pending delegation request found.`                        | No delegation saved by `send_prompt`  | Run `send_prompt` first to generate a request        |
 | `Signing daemon is already running.`                          | Daemon already started                | Use `signer-daemon status` to confirm                |
 | `Signing daemon is not running.`                              | Daemon not started or already stopped | Run `signer-daemon start`                            |
+| `Chain "X" (ID: N) is not supported by CoinFello.`            | Unsupported chain in delegation       | Use a supported chain (see Supported Chains above)   |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinfello/agent-cli",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "CLI for managing a web3 smart account and executing blockchain transactions via CoinFello",
   "repository": "CoinFello/agent-cli",
   "homepage": "https://coinfello.com",

--- a/src/account.ts
+++ b/src/account.ts
@@ -38,9 +38,8 @@ export function resolveChainById(chainId: number): Chain {
 }
 
 export function resolveChainInput(chainInput: string | number): Chain {
-  const chain = typeof chainInput === 'number'
-    ? resolveChainById(chainInput)
-    : resolveChain(chainInput)
+  const chain =
+    typeof chainInput === 'number' ? resolveChainById(chainInput) : resolveChain(chainInput)
 
   assertChainSupported(chain)
 
@@ -53,15 +52,15 @@ export function resolveChainInput(chainInput: string | number): Chain {
  * outside this set would result in permanently locked funds.
  */
 const SUPPORTED_CHAINS_MAP: Record<number, string> = {
-  1:        'Ethereum',
-  10:       'OP Mainnet',
-  56:       'BNB Smart Chain',
-  137:      'Polygon',
-  8453:     'Base',
-  42161:    'Arbitrum One',
-  59144:    'Linea',
+  1: 'Ethereum',
+  10: 'OP Mainnet',
+  56: 'BNB Smart Chain',
+  137: 'Polygon',
+  8453: 'Base',
+  42161: 'Arbitrum One',
+  59144: 'Linea',
   11155111: 'Sepolia (testnet)',
-  84532:    'Base Sepolia (testnet)',
+  84532: 'Base Sepolia (testnet)',
 }
 
 const SUPPORTED_CHAIN_IDS = new Set(Object.keys(SUPPORTED_CHAINS_MAP).map(Number))
@@ -74,8 +73,8 @@ function assertChainSupported(chain: Chain): void {
   if (!SUPPORTED_CHAIN_IDS.has(chain.id)) {
     throw new Error(
       `Chain "${chain.name}" (ID: ${chain.id}) is not supported by CoinFello. ` +
-      `Sending funds to a smart account on an unsupported chain will result in locked funds. ` +
-      `Supported chains: ${getSupportedChainNames().join(', ')}.`
+        `Sending funds to a smart account on an unsupported chain will result in locked funds. ` +
+        `Supported chains: ${getSupportedChainNames().join(', ')}.`
     )
   }
 }

--- a/src/account.ts
+++ b/src/account.ts
@@ -69,6 +69,14 @@ export function getSupportedChainNames(): string[] {
   return Object.values(SUPPORTED_CHAINS_MAP)
 }
 
+export function printSupportedChainsWarning(): void {
+  console.log('')
+  console.warn(
+    `⚠️  Only fund this address on supported networks: ${getSupportedChainNames().join(', ')}.`
+  )
+  console.warn('   Funds sent on unsupported networks cannot be recovered.')
+}
+
 function assertChainSupported(chain: Chain): void {
   if (!SUPPORTED_CHAIN_IDS.has(chain.id)) {
     throw new Error(

--- a/src/account.ts
+++ b/src/account.ts
@@ -70,7 +70,6 @@ export function getSupportedChainNames(): string[] {
 }
 
 export function printSupportedChainsWarning(): void {
-  console.log('')
   console.warn(
     `⚠️  Only fund this address on supported networks: ${getSupportedChainNames().join(', ')}.`
   )

--- a/src/account.ts
+++ b/src/account.ts
@@ -38,10 +38,46 @@ export function resolveChainById(chainId: number): Chain {
 }
 
 export function resolveChainInput(chainInput: string | number): Chain {
-  if (typeof chainInput === 'number') {
-    return resolveChainById(chainInput)
+  const chain = typeof chainInput === 'number'
+    ? resolveChainById(chainInput)
+    : resolveChain(chainInput)
+
+  assertChainSupported(chain)
+
+  return chain
+}
+
+/**
+ * Chains where both the MetaMask delegation framework contracts are deployed
+ * AND CoinFello infrastructure (RPC, backend) is configured. Using a chain
+ * outside this set would result in permanently locked funds.
+ */
+const SUPPORTED_CHAINS_MAP: Record<number, string> = {
+  1:        'Ethereum',
+  10:       'OP Mainnet',
+  56:       'BNB Smart Chain',
+  137:      'Polygon',
+  8453:     'Base',
+  42161:    'Arbitrum One',
+  59144:    'Linea',
+  11155111: 'Sepolia (testnet)',
+  84532:    'Base Sepolia (testnet)',
+}
+
+const SUPPORTED_CHAIN_IDS = new Set(Object.keys(SUPPORTED_CHAINS_MAP).map(Number))
+
+export function getSupportedChainNames(): string[] {
+  return Object.values(SUPPORTED_CHAINS_MAP)
+}
+
+function assertChainSupported(chain: Chain): void {
+  if (!SUPPORTED_CHAIN_IDS.has(chain.id)) {
+    throw new Error(
+      `Chain "${chain.name}" (ID: ${chain.id}) is not supported by CoinFello. ` +
+      `Sending funds to a smart account on an unsupported chain will result in locked funds. ` +
+      `Supported chains: ${getSupportedChainNames().join(', ')}.`
+    )
   }
-  return resolveChain(chainInput)
 }
 
 export async function createSmartAccount(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
 import { Command } from 'commander'
-import { createSmartAccount, createSmartAccountWithSecureEnclave, getSupportedChainNames } from './account.js'
+import {
+  createSmartAccount,
+  createSmartAccountWithSecureEnclave,
+  getSupportedChainNames,
+} from './account.js'
 import { loadConfig, saveConfig, CONFIG_PATH } from './config.js'
 import { sendConversation, BASE_URL_V1, BASE_URL } from './api.js'
 import { loadSessionToken } from './cookies.js'
@@ -74,7 +78,9 @@ program
         console.log(`Key tag: ${keyTag}`)
         console.log(`Config saved to: ${CONFIG_PATH}`)
         console.log('')
-        console.warn(`⚠️  Only fund this address on supported networks: ${getSupportedChainNames().join(', ')}.`)
+        console.warn(
+          `⚠️  Only fund this address on supported networks: ${getSupportedChainNames().join(', ')}.`
+        )
         console.warn('   Funds sent on unsupported networks cannot be recovered.')
       } else {
         if (!opts.useUnsafePrivateKey) {
@@ -95,7 +101,9 @@ program
         console.log(`Address: ${address}`)
         console.log(`Config saved to: ${CONFIG_PATH}`)
         console.log('')
-        console.warn(`⚠️  Only fund this address on supported networks: ${getSupportedChainNames().join(', ')}.`)
+        console.warn(
+          `⚠️  Only fund this address on supported networks: ${getSupportedChainNames().join(', ')}.`
+        )
         console.warn('   Funds sent on unsupported networks cannot be recovered.')
       }
     } catch (err) {
@@ -118,7 +126,9 @@ program
 
       console.log(config.smart_account_address)
       console.log('')
-      console.warn(`⚠️  Only fund this address on supported networks: ${getSupportedChainNames().join(', ')}.`)
+      console.warn(
+        `⚠️  Only fund this address on supported networks: ${getSupportedChainNames().join(', ')}.`
+      )
       console.warn('   Funds sent on unsupported networks cannot be recovered.')
     } catch (err) {
       console.error(`Failed to get account: ${(err as Error).message}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander'
 import {
   createSmartAccount,
   createSmartAccountWithSecureEnclave,
-  getSupportedChainNames,
+  printSupportedChainsWarning,
 } from './account.js'
 import { loadConfig, saveConfig, CONFIG_PATH } from './config.js'
 import { sendConversation, BASE_URL_V1, BASE_URL } from './api.js'
@@ -77,11 +77,7 @@ program
         console.log(`Address: ${address}`)
         console.log(`Key tag: ${keyTag}`)
         console.log(`Config saved to: ${CONFIG_PATH}`)
-        console.log('')
-        console.warn(
-          `⚠️  Only fund this address on supported networks: ${getSupportedChainNames().join(', ')}.`
-        )
-        console.warn('   Funds sent on unsupported networks cannot be recovered.')
+        printSupportedChainsWarning()
       } else {
         if (!opts.useUnsafePrivateKey) {
           console.warn(
@@ -100,11 +96,7 @@ program
         console.log('Smart account created successfully.')
         console.log(`Address: ${address}`)
         console.log(`Config saved to: ${CONFIG_PATH}`)
-        console.log('')
-        console.warn(
-          `⚠️  Only fund this address on supported networks: ${getSupportedChainNames().join(', ')}.`
-        )
-        console.warn('   Funds sent on unsupported networks cannot be recovered.')
+        printSupportedChainsWarning()
       }
     } catch (err) {
       console.error(`Failed to create account: ${(err as Error).message}`)
@@ -125,11 +117,7 @@ program
       }
 
       console.log(config.smart_account_address)
-      console.log('')
-      console.warn(
-        `⚠️  Only fund this address on supported networks: ${getSupportedChainNames().join(', ')}.`
-      )
-      console.warn('   Funds sent on unsupported networks cannot be recovered.')
+      printSupportedChainsWarning()
     } catch (err) {
       console.error(`Failed to get account: ${(err as Error).message}`)
       process.exit(1)

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,6 @@ program
         console.log(`Address: ${address}`)
         console.log(`Key tag: ${keyTag}`)
         console.log(`Config saved to: ${CONFIG_PATH}`)
-        printSupportedChainsWarning()
       } else {
         if (!opts.useUnsafePrivateKey) {
           console.warn(
@@ -96,8 +95,9 @@ program
         console.log('Smart account created successfully.')
         console.log(`Address: ${address}`)
         console.log(`Config saved to: ${CONFIG_PATH}`)
-        printSupportedChainsWarning()
       }
+
+      printSupportedChainsWarning()
     } catch (err) {
       console.error(`Failed to create account: ${(err as Error).message}`)
       process.exit(1)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander'
-import { createSmartAccount, createSmartAccountWithSecureEnclave } from './account.js'
+import { createSmartAccount, createSmartAccountWithSecureEnclave, getSupportedChainNames } from './account.js'
 import { loadConfig, saveConfig, CONFIG_PATH } from './config.js'
 import { sendConversation, BASE_URL_V1, BASE_URL } from './api.js'
 import { loadSessionToken } from './cookies.js'
@@ -73,6 +73,9 @@ program
         console.log(`Address: ${address}`)
         console.log(`Key tag: ${keyTag}`)
         console.log(`Config saved to: ${CONFIG_PATH}`)
+        console.log('')
+        console.warn(`⚠️  Only fund this address on supported networks: ${getSupportedChainNames().join(', ')}.`)
+        console.warn('   Funds sent on unsupported networks cannot be recovered.')
       } else {
         if (!opts.useUnsafePrivateKey) {
           console.warn(
@@ -91,6 +94,9 @@ program
         console.log('Smart account created successfully.')
         console.log(`Address: ${address}`)
         console.log(`Config saved to: ${CONFIG_PATH}`)
+        console.log('')
+        console.warn(`⚠️  Only fund this address on supported networks: ${getSupportedChainNames().join(', ')}.`)
+        console.warn('   Funds sent on unsupported networks cannot be recovered.')
       }
     } catch (err) {
       console.error(`Failed to create account: ${(err as Error).message}`)
@@ -111,6 +117,9 @@ program
       }
 
       console.log(config.smart_account_address)
+      console.log('')
+      console.warn(`⚠️  Only fund this address on supported networks: ${getSupportedChainNames().join(', ')}.`)
+      console.warn('   Funds sent on unsupported networks cannot be recovered.')
     } catch (err) {
       console.error(`Failed to get account: ${(err as Error).message}`)
       process.exit(1)


### PR DESCRIPTION
## Summary
- Adds a chain allowlist in `resolveChainInput()` that rejects any chain where CoinFello infra + MetaMask delegation contracts aren't both available — prevents smart account operations on unsupported chains
- Displays supported networks warning when users run `create_account` or `get_account`, so they know which chains are safe to fund before sending anything
- Bumps version to 0.3.3

## Context
A user funded their smart account on Mantle (chain ID 5000) where the MetaMask delegation framework contracts are not deployed. The $50 in ETH is now locked until MetaMask deploys on that chain.

## Test plan
- [x] `get_account` displays supported networks warning
- [x] `create_account` displays supported networks warning (both Secure Enclave and private key paths)
- [x] `approve_delegation_request` for Mantle (chain 5000) is blocked with clear error message
- [x] `tsc --noEmit` passes
- [x] Build succeeds