### PR TITLE
feat: upgrade smart-accounts-kit to 1.1.0, remove Mantle override

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinfello/agent-cli",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "CLI for managing a web3 smart account and executing blockchain transactions via CoinFello",
   "repository": "CoinFello/agent-cli",
   "homepage": "https://coinfello.com",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.24.0",
   "dependencies": {
-    "@metamask/smart-accounts-kit": "0.4.0-beta.1",
+    "@metamask/smart-accounts-kit": "1.1.0",
     "commander": "^14.0.3",
     "tough-cookie": "^6.0.0",
     "viem": "^2.45.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     dependencies:
       '@metamask/smart-accounts-kit':
-        specifier: 0.4.0-beta.1
-        version: 0.4.0-beta.1(viem@2.45.1(typescript@5.9.3))
+        specifier: 1.1.0
+        version: 1.1.0(typescript@5.9.3)(viem@2.45.1(typescript@5.9.3))
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -309,20 +309,20 @@ packages:
     resolution: {integrity: sha512-a/l0DiSIr7+CBYVpHygUa3ztSlYLFCQMsklLna+t6qmNY9+eIO5TedNxhyIyvaJ+4cN7TLy0NQFbp9FV3X2ktg==}
     engines: {node: ^18.18 || ^20.14 || >=22}
 
-  '@metamask/delegation-abis@0.12.0-beta.0':
-    resolution: {integrity: sha512-2I+nk15BSCWy2YTNE3bxMxqTDUqUJBque5A91wXqn0e3NYLzSg3DEdtc8VebUVbgP9IoFhRhHioPwzd/z+xPoQ==}
+  '@metamask/delegation-abis@1.0.0':
+    resolution: {integrity: sha512-AkrtrXD27yYCu0t0wHrY/Jburlc4HleMVGNlp4DPMljCJOoOg55TIDicAuxZp0QKVtffZ+49DZ8Ww6RBqM+gdQ==}
     engines: {node: ^18.18 || >=20}
 
-  '@metamask/delegation-core@0.3.0':
-    resolution: {integrity: sha512-a0vMu0pIOKD8AydSdSI991SY6BN0XzGhyXoaKbNg55NchyTyNMBuoAXZ92GS8+/jGtyIouQBglh6CUxhZZHmVw==}
+  '@metamask/delegation-core@1.0.0':
+    resolution: {integrity: sha512-ULcSnAxUZC+HdnkteZ53IVDmbvBsjP0E8agF0iqFPbYirJLHvnnNWX/R1XmjqDgeA3G7kBfSP7IqvDRwD6jF4w==}
     engines: {node: ^18.18 || >=20}
 
-  '@metamask/delegation-deployments@0.16.0':
-    resolution: {integrity: sha512-Fm+m+ZPQ1RC0V/PK0Qsoznaeom1ihAoQ7LX2qZl9OmmIKdoyVZQH3gp59hwpPuMyeSgNZ8Cqe3TBi61B7Ja+Pw==}
+  '@metamask/delegation-deployments@1.1.0':
+    resolution: {integrity: sha512-HARqnS/8qjNhMqmsjP45GUpUSwE7PrVsKrYB5iHxcAfe/U//qbxa5T3KT3ALStB6A463BxMPdR99yTNJx7wbfg==}
     engines: {node: ^18.18 || >=20}
 
-  '@metamask/smart-accounts-kit@0.4.0-beta.1':
-    resolution: {integrity: sha512-VSU27YjSpo3AEKvpLY3niwUSruMlnXu1R59eQgY4pqGE1xjKPi29kANbTrGzpH9KGq2PtJmpG5oIhuA7YX2+5g==}
+  '@metamask/smart-accounts-kit@1.1.0':
+    resolution: {integrity: sha512-4rFM9Ym5nPOsZzt0Y0lnRgDYAeD6iYSCRHkVW19SqF0Xj2OPnCIP29G6XwPNh1pdciflJ5T//avNdS5rc3Er8Q==}
     engines: {node: ^18.18 || >=20}
     peerDependencies:
       viem: ^2.31.4
@@ -989,6 +989,14 @@ packages:
       typescript:
         optional: true
 
+  ox@0.8.1:
+    resolution: {integrity: sha512-e+z5epnzV+Zuz91YYujecW8cF01mzmrUtWotJ0oEPym/G82uccs7q0WDHTYL3eiONbTUEvcZrptAKLgTBD3u2A==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -1238,9 +1246,6 @@ packages:
       jsdom:
         optional: true
 
-  webauthn-p256@0.0.10:
-    resolution: {integrity: sha512-EeYD+gmIT80YkSIDb2iWq0lq2zbHo1CxHlQTeJ+KkCILWpVy3zASH3ByD4bopzfk0uCwXxLqKGLqp2W4O28VFA==}
-
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1446,9 +1451,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@metamask/delegation-abis@0.12.0-beta.0': {}
+  '@metamask/delegation-abis@1.0.0': {}
 
-  '@metamask/delegation-core@0.3.0':
+  '@metamask/delegation-core@1.0.0':
     dependencies:
       '@metamask/abi-utils': 3.0.0
       '@metamask/utils': 11.9.0
@@ -1456,19 +1461,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@metamask/delegation-deployments@0.16.0': {}
+  '@metamask/delegation-deployments@1.1.0': {}
 
-  '@metamask/smart-accounts-kit@0.4.0-beta.1(viem@2.45.1(typescript@5.9.3))':
+  '@metamask/smart-accounts-kit@1.1.0(typescript@5.9.3)(viem@2.45.1(typescript@5.9.3))':
     dependencies:
       '@metamask/7715-permission-types': 0.5.0
-      '@metamask/delegation-abis': 0.12.0-beta.0
-      '@metamask/delegation-core': 0.3.0
-      '@metamask/delegation-deployments': 0.16.0
+      '@metamask/delegation-abis': 1.0.0
+      '@metamask/delegation-core': 1.0.0
+      '@metamask/delegation-deployments': 1.1.0
       buffer: 6.0.3
+      ox: 0.8.1(typescript@5.9.3)
       viem: 2.45.1(typescript@5.9.3)
-      webauthn-p256: 0.0.10
     transitivePeerDependencies:
       - supports-color
+      - typescript
+      - zod
 
   '@metamask/superstruct@3.2.1': {}
 
@@ -2134,6 +2141,21 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  ox@0.8.1(typescript@5.9.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -2354,11 +2376,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  webauthn-p256@0.0.10:
-    dependencies:
-      '@noble/curves': 1.9.7
-      '@noble/hashes': 1.8.0
 
   which@2.0.2:
     dependencies:

--- a/src/account.ts
+++ b/src/account.ts
@@ -57,6 +57,7 @@ const SUPPORTED_CHAINS_MAP: Record<number, string> = {
   56: 'BNB Smart Chain',
   137: 'Polygon',
   8453: 'Base',
+  5000: 'Mantle',
   42161: 'Arbitrum One',
   59144: 'Linea',
   11155111: 'Sepolia (testnet)',

--- a/src/services/createPublicClient.ts
+++ b/src/services/createPublicClient.ts
@@ -12,6 +12,7 @@ const QUICKNODE_SLUGS: Record<number, string> = {
   8453: '.base-mainnet',
   84532: '.base-sepolia',
   10: '.optimism',
+  5000: '.mantle-mainnet',
   42161: '.arbitrum-mainnet',
   11155111: '.ethereum-sepolia',
 }


### PR DESCRIPTION
## Summary
- Upgrades `@metamask/smart-accounts-kit` from `0.4.0-beta.1` to `1.1.0` — the new version bundles `@metamask/delegation-deployments@1.1.0` which includes native Mantle (chain ID 5000) contract deployments
- Removes `mantle-environment.ts` side-effect import from `account.ts` — the manual `overrideDeployedEnvironment()` call is no longer needed since the package now includes Mantle natively
- Includes pre-existing Mantle RPC slug in `createPublicClient.ts`

## Context
The MetaMask smart account kit team published official Mantle deployments. This means we no longer need to manually register the Mantle delegation framework contract addresses via `overrideDeployedEnvironment()`. The contract addresses are identical (deterministic CREATE2) so there is no behavioral change.

## Test plan
- [ ] `pnpm codecheck` passes (verified locally)
- [ ] `pnpm prettier` passes (verified locally)
- [ ] `coinfello create_account` still works on Mantle
- [ ] `coinfello get_account` still shows Mantle in supported chains warning
- [ ] Delegation creation on Mantle still works end-to-end