### PR TITLE
docs: add Mantle to supported chain lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The CLI uses [QuickNode](https://www.quicknode.com/) as its RPC provider. Config
 
 If `RPC_BASE_URL` and `RPC_API_KEY` are both set, the CLI routes requests through QuickNode for supported chains. If either is missing, it falls back to the chain's default public RPC.
 
-**Supported chains:** Ethereum (1), Polygon (137), BSC (56), Linea (59144), Base (8453), Base Sepolia (84532), Optimism (10), Arbitrum (42161), Ethereum Sepolia (11155111). Unsupported chains fall back to the default public RPC.
+**Supported chains:** Ethereum (1), Optimism (10), BSC (56), Polygon (137), Mantle (5000), Base (8453), Arbitrum (42161), Linea (59144), Sepolia (11155111), Base Sepolia (84532). Unsupported chains fall back to the default public RPC.
 
 **Local development:** Set `RPC_URL_OVERRIDE` (e.g. `http://127.0.0.1:8545`) to route all RPC calls through a custom URL, regardless of chain.
 

--- a/coinfello/SKILL.md
+++ b/coinfello/SKILL.md
@@ -43,7 +43,7 @@ The CLI is available via `npx @coinfello/agent-cli@latest`. No manual build step
 | `RPC_API_KEY`        | No       | —                            | QuickNode API key                                                                  |
 | `RPC_URL_OVERRIDE`   | No       | —                            | Custom RPC URL override for development/testing (overrides all other RPC settings) |
 
-If both `RPC_BASE_URL` and `RPC_API_KEY` are set, the CLI routes RPC requests through QuickNode for supported chains (Ethereum, Polygon, BSC, Linea, Base, Base Sepolia, Optimism, Arbitrum, Ethereum Sepolia). If either is missing or the chain is not supported, it falls back to the chain's default public RPC.
+If both `RPC_BASE_URL` and `RPC_API_KEY` are set, the CLI routes RPC requests through QuickNode for supported chains (Ethereum, Optimism, BSC, Polygon, Mantle, Base, Arbitrum, Linea, Sepolia, Base Sepolia). If either is missing or the chain is not supported, it falls back to the chain's default public RPC.
 
 Set `RPC_URL_OVERRIDE` (e.g. `http://127.0.0.1:8545`) to route all RPC calls through a custom URL, regardless of chain or other RPC settings.
 
@@ -233,7 +233,7 @@ These are approximate ranges under normal network conditions. L2s like Base are 
 - **No smart account**: Run `create_account` before `send_prompt`. The CLI checks for a saved private key and address in config.
 - **Not signed in**: Run `sign_in` before `send_prompt` if the server requires authentication.
 - **Invalid chain name**: The CLI throws an error listing valid viem chain names.
-- **Unsupported chain**: The CLI rejects chains where CoinFello infrastructure and MetaMask delegation contracts aren't available. Supported chains: Ethereum, OP Mainnet, BNB Smart Chain, Polygon, Base, Arbitrum One, Linea, Sepolia, Base Sepolia. **Funding a smart account on any other chain will result in permanently locked funds.**
+- **Unsupported chain**: The CLI rejects chains where CoinFello infrastructure and MetaMask delegation contracts aren't available. Supported chains: Ethereum, OP Mainnet, BNB Smart Chain, Polygon, Mantle, Base, Arbitrum One, Linea, Sepolia, Base Sepolia. **Funding a smart account on any other chain will result in permanently locked funds.**
 - **Read-only response**: If the server returns a text response with no transaction, the CLI prints it and exits without creating a delegation.
 
 ## Bug Reports & Support

--- a/coinfello/references/REFERENCE.md
+++ b/coinfello/references/REFERENCE.md
@@ -191,6 +191,7 @@ Each subdelegation is created with a unique random salt to ensure delegation uni
 | `optimism`    | 10       | OP Mainnet               |
 | `bsc`         | 56       | BNB Smart Chain          |
 | `polygon`     | 137      | Polygon PoS              |
+| `mantle`      | 5000     | Mantle mainnet           |
 | `base`        | 8453     | Base                     |
 | `arbitrum`    | 42161    | Arbitrum One             |
 | `linea`       | 59144    | Linea mainnet            |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinfello/agent-cli",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "CLI for managing a web3 smart account and executing blockchain transactions via CoinFello",
   "repository": "CoinFello/agent-cli",
   "homepage": "https://coinfello.com",


### PR DESCRIPTION
## Summary
- Updates hardcoded chain lists in `README.md`, `SKILL.md`, and `REFERENCE.md` to include Mantle (5000)

## Context
The runtime code (`SUPPORTED_CHAINS_MAP` in `account.ts`) already included Mantle before this PR — added in #21. The static docs were just out of sync. This syncs them.

**Files changed:**
- `README.md` — RPC supported chains list
- `coinfello/SKILL.md` — QuickNode chains list + unsupported chain error copy
- `coinfello/references/REFERENCE.md` — Supported Chains table (adds `mantle | 5000 | Mantle mainnet` row)

## Test plan
- [x] `pnpm prettier` passes ✅
- [x] `node dist/index.js get_account` shows Mantle in the warning output ✅ (verified during testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)